### PR TITLE
Add backend-specific verification outputs and comparison script

### DIFF
--- a/compare_fft_results.py
+++ b/compare_fft_results.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Build VkFFT with CUDA and OpenCL backends, run verification test,
+and compare FFT outputs to ensure they are numerically similar.
+"""
+import subprocess
+import re
+import math
+import os
+
+
+def run(cmd, **kwargs):
+    print('Running', ' '.join(cmd))
+    subprocess.run(cmd, check=True, **kwargs)
+
+
+def build_and_run(backend, build_dir):
+    if not os.path.exists(build_dir):
+        os.makedirs(build_dir)
+    run(["cmake", "-S", ".", "-B", build_dir, f"-DVKFFT_BACKEND={backend}"])
+    run(["cmake", "--build", build_dir, "-j"])
+    exe = os.path.join(build_dir, "VkFFT_TestSuite")
+    run([exe, "-vkfft", "9999"])
+    if backend == 1:
+        return "fft_verification_results_cuda.txt"
+    elif backend == 3:
+        return "fft_verification_results_opencl.txt"
+    else:
+        raise ValueError("Unsupported backend")
+
+
+def parse_results(path):
+    values = []
+    with open(path) as f:
+        for line in f:
+            if line.startswith("output["):
+                m = re.search(r"output\\[\\d+\\] = ([^ ]+) \+ ([^ ]+)i", line)
+                if m:
+                    values.append(complex(float(m.group(1)), float(m.group(2))))
+    return values
+
+
+cuda_file = build_and_run(1, "build")
+opencl_file = build_and_run(3, "build_opencl")
+
+cuda_vals = parse_results(cuda_file)
+opencl_vals = parse_results(opencl_file)
+
+if len(cuda_vals) != len(opencl_vals):
+    raise RuntimeError("Result lengths differ")
+
+max_diff = max(abs(a - b) for a, b in zip(cuda_vals, opencl_vals))
+print("Max difference between CUDA and OpenCL FFT results:", max_diff)
+
+assert max_diff < 1e-4, "FFT results differ too much: %g" % max_diff
+print("CUDA and OpenCL FFT outputs are sufficiently close.")

--- a/sample_verification.cpp
+++ b/sample_verification.cpp
@@ -86,7 +86,13 @@ VkFFTResult sample_verification_VkFFT_single(VkGPU* vkGPU, uint64_t file_output,
     }
 
     // Print input data
+#if (VKFFT_BACKEND==1)
+    FILE* result_file = fopen("fft_verification_results_cuda.txt", "w");
+#elif (VKFFT_BACKEND==3)
+    FILE* result_file = fopen("fft_verification_results_opencl.txt", "w");
+#else
     FILE* result_file = fopen("fft_verification_results.txt", "w");
+#endif
     if (result_file) {
         fprintf(result_file, "FFT Verification Results\n");
         fprintf(result_file, "========================\n\n");
@@ -388,7 +394,13 @@ VkFFTResult sample_verification_VkFFT_single(VkGPU* vkGPU, uint64_t file_output,
     // Cleanup
     if (result_file) {
         fclose(result_file);
+#if (VKFFT_BACKEND==1)
+        printf("\nResults saved to fft_verification_results_cuda.txt\n");
+#elif (VKFFT_BACKEND==3)
+        printf("\nResults saved to fft_verification_results_opencl.txt\n");
+#else
         printf("\nResults saved to fft_verification_results.txt\n");
+#endif
     }
 
     deleteVkFFT(&app);


### PR DESCRIPTION
## Summary
- Write backend-aware filenames for FFT verification results so CUDA and OpenCL runs store separate output files
- Add `compare_fft_results.py` to build CUDA/OpenCL backends and compare FFT outputs

## Testing
- `python3 compare_fft_results.py` *(fails: Specify CUDA_TOOLKIT_ROOT_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_68ae74fcd10883209ad92547582b6c05